### PR TITLE
Added RegEx for better Track matching

### DIFF
--- a/src/drivers/Apple.js
+++ b/src/drivers/Apple.js
@@ -6,6 +6,8 @@ const Library = require("../library/Library");
 const Playlist = require("../library/Playlist");
 const Track = require("../library/Track");
 
+const trackRegex = require('./trackRegex');
+
 class AppleLibrary extends Library {
     getVendorName() {
         return "Apple";
@@ -28,7 +30,7 @@ class AppleLibrary extends Library {
             Playlists.map(playlist => {
                 const items = playlist["Playlist Items"];
 
-                if(!items || items.length === 0)
+                if (!items || items.length === 0)
                     return debug("Ignoring playlist: %s (empty)", playlist.Name);
 
                 const applePlaylist = ApplePlaylist.fromItunes(playlist);
@@ -39,7 +41,7 @@ class AppleLibrary extends Library {
                     const trackId = track["Track ID"];
                     const selectedTrack = trackIndex[trackId];
 
-                    if(selectedTrack) {
+                    if (selectedTrack) {
                         debug("Adding track %d to playlist %s", trackId, playlist.Name);
                         // Add the tracks
                         applePlaylist.addTrack(selectedTrack);
@@ -60,7 +62,7 @@ class AppleLibrary extends Library {
     static parsePlist(path) {
         return new Promise((resolve, reject) => {
             fs.readFile(path, "utf8", (err, data) => {
-                if(err) return reject(err);
+                if (err) return reject(err);
 
                 const parser = new PlistParser(data);
 
@@ -81,14 +83,14 @@ class ApplePlaylist extends Playlist {
         const playlist = new ApplePlaylist(data.Name);
         playlist.trackCount = data["Playlist Items"].length;
 
-        if(data.Description)
+        if (data.Description)
             playlist.description = data.Description;
 
         return playlist;
     }
 
     toString() {
-        return `${this.name}${ this.description ? " - " + this.description : ""} (${this.trackCount} tracks).`;
+        return `${this.name}${this.description ? " - " + this.description : ""} (${this.trackCount} tracks).`;
     }
 }
 
@@ -101,7 +103,10 @@ class AppleTrack extends Track {
             return trimmed;
         }, {});
 
-        return new Track(data.Name, data.Artist, data.Album);
+        return new Track(
+            trackRegex.removeFeatFromName(data.Name),
+            trackRegex.removeAndFromArtist(data.Artist),
+            data.Album);
     }
 }
 

--- a/src/drivers/trackRegex.js
+++ b/src/drivers/trackRegex.js
@@ -1,0 +1,12 @@
+function removeFeatFromName(name) {
+	return name.replace(/ \(feat\.[\s\S]*\)/gi, "").trim();
+}
+
+function removeAndFromArtist(artist) {
+	return artist.replace(/ (& [\s\S]*)/gi, "").trim();
+}
+
+module.exports = {
+	removeFeatFromName,
+	removeAndFromArtist
+}


### PR DESCRIPTION
### Change
Added RegEx to remove ' (feat. *)' from the Track name field and '&' from the Artist field.

### Improvement
**67% increase in Track matching.** 
(Using my library, it went from 1066 unmatched to 353).

### Description
First of all, thank you for creating such an amazing and useful tool. There's really no other tool that does apple->spotify importing as good as this one. Since I use this a lot, I  just wanted to help others who use it and added just 2 RegExs to guarantee better matches.

I've noticed that music streaming services struggle finding matches if the Track name includes a featured artist and/or the Artist field includes an '&' in the name. 

